### PR TITLE
Make callback parameter optional

### DIFF
--- a/src/ThemesProvider.tsx
+++ b/src/ThemesProvider.tsx
@@ -34,14 +34,18 @@ export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
             const { cb, setTheme, themes } = this.props;
             const channel = addons.getChannel();
             channel.on("selectTheme", setTheme);
-            channel.on("selectTheme", cb);
+            if (cb) {
+                channel.on("selectTheme", cb);
+            }
             channel.emit("setThemes", themes);
         },
         componentWillUnmount() {
             const { cb, setTheme } = this.props;
             const channel = addons.getChannel();
             channel.removeListener("selectTheme", setTheme);
-            channel.removeListener("selectTheme", cb);
+            if (cb) {
+                channel.removeListener("selectTheme", cb);
+            }
         },
     }),
     branch<BaseComponentProps>(

--- a/src/withThemesProvider.tsx
+++ b/src/withThemesProvider.tsx
@@ -4,6 +4,6 @@ import { ThemesProvider } from "./ThemesProvider";
 
 import { Theme } from "./types/Theme";
 
-export const withThemesProvider = (themes: Theme[], cb: (theme: Theme) => void) => (story): JSX.Element => {
+export const withThemesProvider = (themes: Theme[], cb?: (theme: Theme) => void) => (story): JSX.Element => {
     return <ThemesProvider themes={List(themes)} cb={cb}>{story()}</ThemesProvider>;
 };


### PR DESCRIPTION
In `withThemesProvider` it was required, but in `ThemesProvider` it is optional. So I made it optional anywhere.