### PR TITLE
feat: remember theme selection

### DIFF
--- a/example/index.stories.tsx
+++ b/example/index.stories.tsx
@@ -2,4 +2,4 @@ import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { Demo } from "./Demo";
 
-storiesOf("Examples", module).add("Demo", () => <Demo />);
+storiesOf("Examples", module).add("Demo", () => <Demo />).add("Selected theme should persist", () => <Demo />);

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -37,15 +37,17 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
     withState("theme", "setTheme", null),
     withState("themes", "setThemes", List()),
     withHandlers<ThemeProps & ThemeState, ThemeHandler>({
-        onSelectTheme: ({ channel, setTheme }) => (theme) => {
+        onSelectTheme: ({ channel, setTheme, api }) => (theme) => {
             setTheme(theme);
+            api.setQueryParams({ selectedEmotionTheme: theme.name });
             channel.emit("selectTheme", theme);
         },
-        onReceiveThemes: ({ setTheme, setThemes, channel }) => (newThemes: Theme[]) => {
+        onReceiveThemes: ({ setTheme, setThemes, channel, api }) => (newThemes: Theme[]) => {
             const themes = List(newThemes);
+            const themeName = api.getQueryParam("selectedEmotionTheme");
             setThemes(List(themes));
             if (themes.count() > 0) {
-                const theme = themes.first();
+                const theme = themes.find((t: Theme) => t.name === themeName) || themes.first();
                 setTheme(theme);
                 channel.emit("selectTheme", theme);
             }


### PR DESCRIPTION
If you switch between stories, current theme is always fallback to first one. This PR fix that, so selected theme is stored in url.